### PR TITLE
Support Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,28 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+        toxenv: [test]
+        include:
+          - python-version: '3.10'
+            toxenv: lint
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: |
           pip install --upgrade pip
           pip install tox
       - name: Run tests
-        run: tox
+        run: tox -e ${{ matrix.toxenv }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ license = "Apache 2.0"
 zarrsum = "zarr_checksum.cli:cli"
 
 [tool.poetry.dependencies]
-python = "^3.8.10"
+python = "^3.7"
 boto3 = "^1.26.29"
 boto3-stubs = {extras = ["s3"], version = "^1.26.29"}
-zarr = "^2.13.3"
+zarr = "^2.12"
 click = "^8.1.3"
 tqdm = "^4.64.1"
 pydantic = "^1.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zarr-checksum"
-version = "0.2.2"
+version = "0.2.3"
 description = "Checksum support for zarrs stored in various backends"
 readme="README.md"
 homepage="https://github.com/dandi/zarr_checksum"

--- a/zarr_checksum/generators.py
+++ b/zarr_checksum/generators.py
@@ -108,7 +108,7 @@ def yield_files_local(directory: str | Path) -> FileGenerator:
         # Compute md5sum of file
         md5sum = hashlib.md5()
         with open(absolute_path, "rb") as f:
-            while chunk := f.read(8192):
+            for chunk in iter(lambda: f.read(8192), b""):
                 md5sum.update(chunk)
         digest = md5sum.hexdigest()
 


### PR DESCRIPTION
In order for this to be usable in dandi-cli, it needs to work with Python 3.7+.