### PR TITLE
Remove `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup()


### PR DESCRIPTION
As this project uses poetry rather than setuptools, there should be no reason for there to be a `setup.py` file.  Its presence is misleading, and it does nothing.