### PR TITLE
Lower minimum boto3 version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ zarrsum = "zarr_checksum.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-boto3 = "^1.26.29"
-boto3-stubs = {extras = ["s3"], version = "^1.26.29"}
+boto3 = "^1.24"
+boto3-stubs = {extras = ["s3"], version = "^1.24"}
 zarr = "^2.12"
 click = "^8.1.3"
 tqdm = "^4.64.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zarr-checksum"
-version = "0.2.3"
+version = "0.2.4"
 description = "Checksum support for zarrs stored in various backends"
 readme="README.md"
 homepage="https://github.com/dandi/zarr_checksum"


### PR DESCRIPTION
In order for this package to fully replace `ZCTree` from dandi-cli, I need to be able to use it in dandi/dandisets/tools/backups2datalad, which depends on aiobotocore, which currently depends on `botocore <1.27.60, >=1.27.59`, which boto3 is only compatible with in version 1.24.59, which is lower than is currently allowed by zarr_checksum.