### PR TITLE
Avoid importing zarr library unless necessary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zarr-checksum"
-version = "0.2.9"
+version = "0.2.10"
 description = "Checksum support for zarrs stored in various backends"
 readme="README.md"
 homepage="https://github.com/dandi/zarr_checksum"

--- a/zarr_checksum/generators.py
+++ b/zarr_checksum/generators.py
@@ -9,7 +9,6 @@ from typing import Iterable
 import boto3
 from botocore.client import Config
 from tqdm import tqdm
-from zarr.storage import NestedDirectoryStore
 
 
 @dataclass
@@ -94,6 +93,10 @@ def yield_files_s3(
 
 
 def yield_files_local(directory: str | Path) -> FileGenerator:
+    # Avoid importing zarr and its heavy dependencies like numpy unless
+    # necessary
+    from zarr.storage import NestedDirectoryStore
+
     root_path = Path(os.path.expandvars(directory)).expanduser()
     if not root_path.exists():
         raise Exception("Path does not exist")


### PR DESCRIPTION
At the moment, importing `zarr_checksum` automatically & unconditionally causes `zarr` to be imported as well, which results in `numpy` being imported, which is not good for [dandi-cli's "no heavy imports" test](https://github.com/dandi/dandi-cli/blob/cb86c9cb3fad0b8735ad86eb4ba43569d4a0a425/dandi/cli/tests/test_command.py#L41).  This PR moves the single import of `zarr` to inside the only function that makes use of it.