### PR TITLE
Fix license declaration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme="README.md"
 homepage="https://github.com/dandi/zarr_checksum"
 repository="https://github.com/dandi/zarr_checksum"
 authors = ["Kitware, Inc. <kitware@kitware.com>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 
 [tool.poetry.scripts]
 zarrsum = "zarr_checksum.cli:cli"


### PR DESCRIPTION
The proper SPDX identifier for the Apache license is "Apache-2.0", with a hyphen.  The lack of a hyphen was causing poetry to give the project a license classifier of "License :: Other/Proprietary License".